### PR TITLE
GitHub Actionsでactions/checkoutとsetup-nodeをコミットSHA固定

### DIFF
--- a/.github/actions/node-install/action.yaml
+++ b/.github/actions/node-install/action.yaml
@@ -18,7 +18,7 @@ runs:
         version: ${{ inputs.pnpm-version }}
 
     - name: Set Node.js version to ${{ inputs.node-version }}
-      uses: actions/setup-node@v4
+      uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020
       with:
         node-version: ${{ inputs.node-version }}
         cache: pnpm

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -23,7 +23,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout source code
-        uses: actions/checkout@v4
+        uses: actions/checkout@08eba0b27e820071cde6df949e0beb9ba4906955
 
       - name: Setup Node.js and install dependencies
         uses: ./.github/actions/node-install


### PR DESCRIPTION
- close #15 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- チョア
  - CIのGitHub Actions参照をタグから特定コミットに固定し、再現性・セキュリティ・監査性を強化しました。
  - Node.jsセットアップ手順のアクションもコミットハッシュで固定し、依存の予期せぬ更新による不安定化を防止しました。ビルド、インストール、リンティングの実行手順や結果への影響はありません。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->