### PR TITLE
OpenAPI/Swagger UIのルート登録とログ出力を開発環境のみに限定

### DIFF
--- a/server/api/index.ts
+++ b/server/api/index.ts
@@ -12,17 +12,16 @@ const app = new OpenAPIHono().basePath('/api');
  */
 healthHandler(app);
 
-app.doc('/openapi.yaml', {
-  openapi: '3.0.0',
-  info: {
-    version: '1.0.0',
-    title: 'Nuxt Frontend Architect Sample API',
-  },
-});
-
-app.get('/swagger', swaggerUI({ url: '/api/openapi.yaml' }));
-
 if (isDevelopment) {
+  app.doc('/openapi.yaml', {
+    openapi: '3.0.0',
+    info: {
+      version: '1.0.0',
+      title: 'Nuxt Frontend Architect Sample API',
+    },
+  });
+  app.get('/swagger', swaggerUI({ url: '/api/openapi.yaml' }));
+
   consola.info('API Server URLs:');
   consola.info('  Health Check: http://localhost:3000/api/health');
   consola.info('  Swagger UI: http://localhost:3000/api/swagger');


### PR DESCRIPTION
- close #6 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * 開発環境でのみ Swagger UI と OpenAPI 仕様の提供・URLログ出力を有効化。
  * 開発環境内に OpenAPI Spec のURLログを追加。
  * ヘルスチェック／Swagger UI／OpenAPI Spec のコンソール出力を開発環境に限定。
  * 本番環境の挙動や公開APIの利用方法に変更はありません。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->