### PR TITLE
Nodeバージョンの変更と、Nodeバージョンを変更するスクリプトの追加

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -14,7 +14,7 @@ on:
   workflow_dispatch:
 
 env:
-  NODE_VERSION: 22.19.0
+  NODE_VERSION: 22.16.0
   PNPM_VERSION: 10.15.1
 
 jobs:

--- a/.serena/memories/project_overview.md
+++ b/.serena/memories/project_overview.md
@@ -39,7 +39,7 @@ This is a **Nuxt 4 + Hono + TanStack Query フルスタック サンプル** pro
 
 ### Node.js Environment
 
-- Node.js v22.19.0 (managed by Volta)
+- Node.js v22.16.0 (managed by Volta)
 - pnpm v10.15.1 (managed by Volta)
 
 ## Architecture Highlights

--- a/README.md
+++ b/README.md
@@ -110,8 +110,8 @@ sequenceDiagram
 
 以下の環境が必要です：
 
-- **Node.js** v24.7.0 以上
-- **pnpm** v10.15.0 以上（推奨）
+- **Node.js** v22.16.0 以上
+- **pnpm** v10.15.1 以上（推奨）
 
 > このプロジェクトでは[Volta](https://volta.sh/)で Node.js と pnpm のバージョン管理をしています。
 

--- a/package.json
+++ b/package.json
@@ -23,7 +23,8 @@
     "test": "vitest",
     "test:ui": "vitest --ui --coverage",
     "test:coverage": "vitest run --coverage",
-    "generate-types": "openapi-ts && pnpm biome:fix"
+    "generate-types": "openapi-ts && pnpm biome:fix",
+    "sync-versions": "jiti scripts/sync-node-version.ts"
   },
   "dependencies": {
     "@hono/swagger-ui": "0.5.2",

--- a/package.json
+++ b/package.json
@@ -43,7 +43,7 @@
     "@pinia/nuxt": "0.11.2",
     "@pinia/testing": "1.0.2",
     "@types/eslint-plugin-tailwindcss": "3.17.0",
-    "@types/node": "22.18.1",
+    "@types/node": "22.16.5",
     "@vitejs/plugin-vue": "6.0.1",
     "@vitest/coverage-v8": "3.2.4",
     "@vitest/ui": "3.2.4",
@@ -68,7 +68,7 @@
   },
   "packageManager": "pnpm@10.15.1",
   "volta": {
-    "node": "22.19.0",
+    "node": "22.16.0",
     "pnpm": "10.15.1"
   }
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -38,7 +38,7 @@ importers:
         version: 0.82.4(magicast@0.3.5)(typescript@5.9.2)
       '@nuxt/eslint':
         specifier: 1.9.0
-        version: 1.9.0(@typescript-eslint/utils@8.42.0(eslint@9.35.0(jiti@2.5.1))(typescript@5.9.2))(@vue/compiler-sfc@3.5.21)(eslint@9.35.0(jiti@2.5.1))(magicast@0.3.5)(typescript@5.9.2)(vite@7.1.4(@types/node@22.18.1)(jiti@2.5.1)(terser@5.44.0)(yaml@2.8.1))
+        version: 1.9.0(@typescript-eslint/utils@8.42.0(eslint@9.35.0(jiti@2.5.1))(typescript@5.9.2))(@vue/compiler-sfc@3.5.21)(eslint@9.35.0(jiti@2.5.1))(magicast@0.3.5)(typescript@5.9.2)(vite@7.1.4(@types/node@22.16.5)(jiti@2.5.1)(terser@5.44.0)(yaml@2.8.1))
       '@nuxt/test-utils':
         specifier: 3.19.2
         version: 3.19.2(@vitest/ui@3.2.4)(@vue/test-utils@2.4.6)(happy-dom@17.6.3)(magicast@0.3.5)(typescript@5.9.2)(vitest@3.2.4)
@@ -55,11 +55,11 @@ importers:
         specifier: 3.17.0
         version: 3.17.0
       '@types/node':
-        specifier: 22.18.1
-        version: 22.18.1
+        specifier: 22.16.5
+        version: 22.16.5
       '@vitejs/plugin-vue':
         specifier: 6.0.1
-        version: 6.0.1(vite@7.1.4(@types/node@22.18.1)(jiti@2.5.1)(terser@5.44.0)(yaml@2.8.1))(vue@3.5.21(typescript@5.9.2))
+        version: 6.0.1(vite@7.1.4(@types/node@22.16.5)(jiti@2.5.1)(terser@5.44.0)(yaml@2.8.1))(vue@3.5.21(typescript@5.9.2))
       '@vitest/coverage-v8':
         specifier: 3.2.4
         version: 3.2.4(vitest@3.2.4)
@@ -86,7 +86,7 @@ importers:
         version: 17.6.3
       nuxt:
         specifier: 4.1.1
-        version: 4.1.1(@biomejs/biome@2.2.3)(@parcel/watcher@2.5.1)(@types/node@22.18.1)(@vue/compiler-sfc@3.5.21)(db0@0.3.2)(eslint@9.35.0(jiti@2.5.1))(ioredis@5.7.0)(magicast@0.3.5)(optionator@0.9.4)(rollup@4.50.0)(terser@5.44.0)(typescript@5.9.2)(vite@7.1.4(@types/node@22.18.1)(jiti@2.5.1)(terser@5.44.0)(yaml@2.8.1))(vue-tsc@3.0.6(typescript@5.9.2))(yaml@2.8.1)
+        version: 4.1.1(@biomejs/biome@2.2.3)(@parcel/watcher@2.5.1)(@types/node@22.16.5)(@vue/compiler-sfc@3.5.21)(db0@0.3.2)(eslint@9.35.0(jiti@2.5.1))(ioredis@5.7.0)(magicast@0.3.5)(optionator@0.9.4)(rollup@4.50.0)(terser@5.44.0)(typescript@5.9.2)(vite@7.1.4(@types/node@22.16.5)(jiti@2.5.1)(terser@5.44.0)(yaml@2.8.1))(vue-tsc@3.0.6(typescript@5.9.2))(yaml@2.8.1)
       pinia:
         specifier: 3.0.3
         version: 3.0.3(typescript@5.9.2)(vue@3.5.21(typescript@5.9.2))
@@ -101,7 +101,7 @@ importers:
         version: 5.9.2
       vitest:
         specifier: 3.2.4
-        version: 3.2.4(@types/node@22.18.1)(@vitest/ui@3.2.4)(happy-dom@17.6.3)(jiti@2.5.1)(terser@5.44.0)(yaml@2.8.1)
+        version: 3.2.4(@types/node@22.16.5)(@vitest/ui@3.2.4)(happy-dom@17.6.3)(jiti@2.5.1)(terser@5.44.0)(yaml@2.8.1)
       vue:
         specifier: 3.5.21
         version: 3.5.21(typescript@5.9.2)
@@ -1430,8 +1430,8 @@ packages:
   '@types/json-schema@7.0.15':
     resolution: {integrity: sha512-5+fP8P8MFNC+AyZCDxrB2pkZFPGzqQWUzpSeuuVLvm8VMcorNYavBqoFcxK8bQz4Qsbn4oUEEem4wDLfcysGHA==}
 
-  '@types/node@22.18.1':
-    resolution: {integrity: sha512-rzSDyhn4cYznVG+PCzGe1lwuMYJrcBS1fc3JqSa2PvtABwWo+dZ1ij5OVok3tqfpEBCBoaR4d7upFJk73HRJDw==}
+  '@types/node@22.16.5':
+    resolution: {integrity: sha512-bJFoMATwIGaxxx8VJPeM8TonI8t579oRvgAuT8zFugJsJZgzqv0Fu8Mhp68iecjzG7cnN3mO2dJQ5uUM2EFrgQ==}
 
   '@types/parse-path@7.1.0':
     resolution: {integrity: sha512-EULJ8LApcVEPbrfND0cRQqutIOdiIgJ1Mgrhpy755r14xMohPTEpkV/k28SJvuOs9bHRFW8x+KeDAEPiGQPB9Q==}
@@ -5546,11 +5546,11 @@ snapshots:
 
   '@nuxt/devalue@2.0.2': {}
 
-  '@nuxt/devtools-kit@2.6.3(magicast@0.3.5)(vite@7.1.4(@types/node@22.18.1)(jiti@2.5.1)(terser@5.44.0)(yaml@2.8.1))':
+  '@nuxt/devtools-kit@2.6.3(magicast@0.3.5)(vite@7.1.4(@types/node@22.16.5)(jiti@2.5.1)(terser@5.44.0)(yaml@2.8.1))':
     dependencies:
       '@nuxt/kit': 3.19.1(magicast@0.3.5)
       execa: 8.0.1
-      vite: 7.1.4(@types/node@22.18.1)(jiti@2.5.1)(terser@5.44.0)(yaml@2.8.1)
+      vite: 7.1.4(@types/node@22.16.5)(jiti@2.5.1)(terser@5.44.0)(yaml@2.8.1)
     transitivePeerDependencies:
       - magicast
 
@@ -5565,12 +5565,12 @@ snapshots:
       prompts: 2.4.2
       semver: 7.7.2
 
-  '@nuxt/devtools@2.6.3(vite@7.1.4(@types/node@22.18.1)(jiti@2.5.1)(terser@5.44.0)(yaml@2.8.1))(vue@3.5.21(typescript@5.9.2))':
+  '@nuxt/devtools@2.6.3(vite@7.1.4(@types/node@22.16.5)(jiti@2.5.1)(terser@5.44.0)(yaml@2.8.1))(vue@3.5.21(typescript@5.9.2))':
     dependencies:
-      '@nuxt/devtools-kit': 2.6.3(magicast@0.3.5)(vite@7.1.4(@types/node@22.18.1)(jiti@2.5.1)(terser@5.44.0)(yaml@2.8.1))
+      '@nuxt/devtools-kit': 2.6.3(magicast@0.3.5)(vite@7.1.4(@types/node@22.16.5)(jiti@2.5.1)(terser@5.44.0)(yaml@2.8.1))
       '@nuxt/devtools-wizard': 2.6.3
       '@nuxt/kit': 3.19.1(magicast@0.3.5)
-      '@vue/devtools-core': 7.7.7(vite@7.1.4(@types/node@22.18.1)(jiti@2.5.1)(terser@5.44.0)(yaml@2.8.1))(vue@3.5.21(typescript@5.9.2))
+      '@vue/devtools-core': 7.7.7(vite@7.1.4(@types/node@22.16.5)(jiti@2.5.1)(terser@5.44.0)(yaml@2.8.1))(vue@3.5.21(typescript@5.9.2))
       '@vue/devtools-kit': 7.7.7
       birpc: 2.5.0
       consola: 3.4.2
@@ -5595,9 +5595,9 @@ snapshots:
       sirv: 3.0.2
       structured-clone-es: 1.0.0
       tinyglobby: 0.2.14
-      vite: 7.1.4(@types/node@22.18.1)(jiti@2.5.1)(terser@5.44.0)(yaml@2.8.1)
-      vite-plugin-inspect: 11.3.3(@nuxt/kit@3.19.1(magicast@0.3.5))(vite@7.1.4(@types/node@22.18.1)(jiti@2.5.1)(terser@5.44.0)(yaml@2.8.1))
-      vite-plugin-vue-tracer: 1.0.0(vite@7.1.4(@types/node@22.18.1)(jiti@2.5.1)(terser@5.44.0)(yaml@2.8.1))(vue@3.5.21(typescript@5.9.2))
+      vite: 7.1.4(@types/node@22.16.5)(jiti@2.5.1)(terser@5.44.0)(yaml@2.8.1)
+      vite-plugin-inspect: 11.3.3(@nuxt/kit@3.19.1(magicast@0.3.5))(vite@7.1.4(@types/node@22.16.5)(jiti@2.5.1)(terser@5.44.0)(yaml@2.8.1))
+      vite-plugin-vue-tracer: 1.0.0(vite@7.1.4(@types/node@22.16.5)(jiti@2.5.1)(terser@5.44.0)(yaml@2.8.1))(vue@3.5.21(typescript@5.9.2))
       which: 5.0.0
       ws: 8.18.3
     transitivePeerDependencies:
@@ -5646,10 +5646,10 @@ snapshots:
       - supports-color
       - typescript
 
-  '@nuxt/eslint@1.9.0(@typescript-eslint/utils@8.42.0(eslint@9.35.0(jiti@2.5.1))(typescript@5.9.2))(@vue/compiler-sfc@3.5.21)(eslint@9.35.0(jiti@2.5.1))(magicast@0.3.5)(typescript@5.9.2)(vite@7.1.4(@types/node@22.18.1)(jiti@2.5.1)(terser@5.44.0)(yaml@2.8.1))':
+  '@nuxt/eslint@1.9.0(@typescript-eslint/utils@8.42.0(eslint@9.35.0(jiti@2.5.1))(typescript@5.9.2))(@vue/compiler-sfc@3.5.21)(eslint@9.35.0(jiti@2.5.1))(magicast@0.3.5)(typescript@5.9.2)(vite@7.1.4(@types/node@22.16.5)(jiti@2.5.1)(terser@5.44.0)(yaml@2.8.1))':
     dependencies:
       '@eslint/config-inspector': 1.2.0(eslint@9.35.0(jiti@2.5.1))
-      '@nuxt/devtools-kit': 2.6.3(magicast@0.3.5)(vite@7.1.4(@types/node@22.18.1)(jiti@2.5.1)(terser@5.44.0)(yaml@2.8.1))
+      '@nuxt/devtools-kit': 2.6.3(magicast@0.3.5)(vite@7.1.4(@types/node@22.16.5)(jiti@2.5.1)(terser@5.44.0)(yaml@2.8.1))
       '@nuxt/eslint-config': 1.9.0(@typescript-eslint/utils@8.42.0(eslint@9.35.0(jiti@2.5.1))(typescript@5.9.2))(@vue/compiler-sfc@3.5.21)(eslint@9.35.0(jiti@2.5.1))(typescript@5.9.2)
       '@nuxt/eslint-plugin': 1.9.0(eslint@9.35.0(jiti@2.5.1))(typescript@5.9.2)
       '@nuxt/kit': 4.1.1(magicast@0.3.5)
@@ -5785,17 +5785,17 @@ snapshots:
       '@vitest/ui': 3.2.4(vitest@3.2.4)
       '@vue/test-utils': 2.4.6
       happy-dom: 17.6.3
-      vitest: 3.2.4(@types/node@22.18.1)(@vitest/ui@3.2.4)(happy-dom@17.6.3)(jiti@2.5.1)(terser@5.44.0)(yaml@2.8.1)
+      vitest: 3.2.4(@types/node@22.16.5)(@vitest/ui@3.2.4)(happy-dom@17.6.3)(jiti@2.5.1)(terser@5.44.0)(yaml@2.8.1)
     transitivePeerDependencies:
       - magicast
       - typescript
 
-  '@nuxt/vite-builder@4.1.1(@biomejs/biome@2.2.3)(@types/node@22.18.1)(eslint@9.35.0(jiti@2.5.1))(magicast@0.3.5)(optionator@0.9.4)(rollup@4.50.0)(terser@5.44.0)(typescript@5.9.2)(vue-tsc@3.0.6(typescript@5.9.2))(vue@3.5.21(typescript@5.9.2))(yaml@2.8.1)':
+  '@nuxt/vite-builder@4.1.1(@biomejs/biome@2.2.3)(@types/node@22.16.5)(eslint@9.35.0(jiti@2.5.1))(magicast@0.3.5)(optionator@0.9.4)(rollup@4.50.0)(terser@5.44.0)(typescript@5.9.2)(vue-tsc@3.0.6(typescript@5.9.2))(vue@3.5.21(typescript@5.9.2))(yaml@2.8.1)':
     dependencies:
       '@nuxt/kit': 4.1.1(magicast@0.3.5)
       '@rollup/plugin-replace': 6.0.2(rollup@4.50.0)
-      '@vitejs/plugin-vue': 6.0.1(vite@7.1.4(@types/node@22.18.1)(jiti@2.5.1)(terser@5.44.0)(yaml@2.8.1))(vue@3.5.21(typescript@5.9.2))
-      '@vitejs/plugin-vue-jsx': 5.1.1(vite@7.1.4(@types/node@22.18.1)(jiti@2.5.1)(terser@5.44.0)(yaml@2.8.1))(vue@3.5.21(typescript@5.9.2))
+      '@vitejs/plugin-vue': 6.0.1(vite@7.1.4(@types/node@22.16.5)(jiti@2.5.1)(terser@5.44.0)(yaml@2.8.1))(vue@3.5.21(typescript@5.9.2))
+      '@vitejs/plugin-vue-jsx': 5.1.1(vite@7.1.4(@types/node@22.16.5)(jiti@2.5.1)(terser@5.44.0)(yaml@2.8.1))(vue@3.5.21(typescript@5.9.2))
       autoprefixer: 10.4.21(postcss@8.5.6)
       consola: 3.4.2
       cssnano: 7.1.1(postcss@8.5.6)
@@ -5817,9 +5817,9 @@ snapshots:
       std-env: 3.9.0
       ufo: 1.6.1
       unenv: 2.0.0-rc.21
-      vite: 7.1.4(@types/node@22.18.1)(jiti@2.5.1)(terser@5.44.0)(yaml@2.8.1)
-      vite-node: 3.2.4(@types/node@22.18.1)(jiti@2.5.1)(terser@5.44.0)(yaml@2.8.1)
-      vite-plugin-checker: 0.10.3(@biomejs/biome@2.2.3)(eslint@9.35.0(jiti@2.5.1))(optionator@0.9.4)(typescript@5.9.2)(vite@7.1.4(@types/node@22.18.1)(jiti@2.5.1)(terser@5.44.0)(yaml@2.8.1))(vue-tsc@3.0.6(typescript@5.9.2))
+      vite: 7.1.4(@types/node@22.16.5)(jiti@2.5.1)(terser@5.44.0)(yaml@2.8.1)
+      vite-node: 3.2.4(@types/node@22.16.5)(jiti@2.5.1)(terser@5.44.0)(yaml@2.8.1)
+      vite-plugin-checker: 0.10.3(@biomejs/biome@2.2.3)(eslint@9.35.0(jiti@2.5.1))(optionator@0.9.4)(typescript@5.9.2)(vite@7.1.4(@types/node@22.16.5)(jiti@2.5.1)(terser@5.44.0)(yaml@2.8.1))(vue-tsc@3.0.6(typescript@5.9.2))
       vue: 3.5.21(typescript@5.9.2)
       vue-bundle-renderer: 2.1.2
     transitivePeerDependencies:
@@ -6292,7 +6292,7 @@ snapshots:
 
   '@types/json-schema@7.0.15': {}
 
-  '@types/node@22.18.1':
+  '@types/node@22.16.5':
     dependencies:
       undici-types: 6.21.0
 
@@ -6479,22 +6479,22 @@ snapshots:
       - rollup
       - supports-color
 
-  '@vitejs/plugin-vue-jsx@5.1.1(vite@7.1.4(@types/node@22.18.1)(jiti@2.5.1)(terser@5.44.0)(yaml@2.8.1))(vue@3.5.21(typescript@5.9.2))':
+  '@vitejs/plugin-vue-jsx@5.1.1(vite@7.1.4(@types/node@22.16.5)(jiti@2.5.1)(terser@5.44.0)(yaml@2.8.1))(vue@3.5.21(typescript@5.9.2))':
     dependencies:
       '@babel/core': 7.28.4
       '@babel/plugin-syntax-typescript': 7.27.1(@babel/core@7.28.4)
       '@babel/plugin-transform-typescript': 7.28.0(@babel/core@7.28.4)
       '@rolldown/pluginutils': 1.0.0-beta.35
       '@vue/babel-plugin-jsx': 1.5.0(@babel/core@7.28.4)
-      vite: 7.1.4(@types/node@22.18.1)(jiti@2.5.1)(terser@5.44.0)(yaml@2.8.1)
+      vite: 7.1.4(@types/node@22.16.5)(jiti@2.5.1)(terser@5.44.0)(yaml@2.8.1)
       vue: 3.5.21(typescript@5.9.2)
     transitivePeerDependencies:
       - supports-color
 
-  '@vitejs/plugin-vue@6.0.1(vite@7.1.4(@types/node@22.18.1)(jiti@2.5.1)(terser@5.44.0)(yaml@2.8.1))(vue@3.5.21(typescript@5.9.2))':
+  '@vitejs/plugin-vue@6.0.1(vite@7.1.4(@types/node@22.16.5)(jiti@2.5.1)(terser@5.44.0)(yaml@2.8.1))(vue@3.5.21(typescript@5.9.2))':
     dependencies:
       '@rolldown/pluginutils': 1.0.0-beta.29
-      vite: 7.1.4(@types/node@22.18.1)(jiti@2.5.1)(terser@5.44.0)(yaml@2.8.1)
+      vite: 7.1.4(@types/node@22.16.5)(jiti@2.5.1)(terser@5.44.0)(yaml@2.8.1)
       vue: 3.5.21(typescript@5.9.2)
 
   '@vitest/coverage-v8@3.2.4(vitest@3.2.4)':
@@ -6512,7 +6512,7 @@ snapshots:
       std-env: 3.9.0
       test-exclude: 7.0.1
       tinyrainbow: 2.0.0
-      vitest: 3.2.4(@types/node@22.18.1)(@vitest/ui@3.2.4)(happy-dom@17.6.3)(jiti@2.5.1)(terser@5.44.0)(yaml@2.8.1)
+      vitest: 3.2.4(@types/node@22.16.5)(@vitest/ui@3.2.4)(happy-dom@17.6.3)(jiti@2.5.1)(terser@5.44.0)(yaml@2.8.1)
     transitivePeerDependencies:
       - supports-color
 
@@ -6524,13 +6524,13 @@ snapshots:
       chai: 5.3.3
       tinyrainbow: 2.0.0
 
-  '@vitest/mocker@3.2.4(vite@7.1.4(@types/node@22.18.1)(jiti@2.5.1)(terser@5.44.0)(yaml@2.8.1))':
+  '@vitest/mocker@3.2.4(vite@7.1.4(@types/node@22.16.5)(jiti@2.5.1)(terser@5.44.0)(yaml@2.8.1))':
     dependencies:
       '@vitest/spy': 3.2.4
       estree-walker: 3.0.3
       magic-string: 0.30.18
     optionalDependencies:
-      vite: 7.1.4(@types/node@22.18.1)(jiti@2.5.1)(terser@5.44.0)(yaml@2.8.1)
+      vite: 7.1.4(@types/node@22.16.5)(jiti@2.5.1)(terser@5.44.0)(yaml@2.8.1)
 
   '@vitest/pretty-format@3.2.4':
     dependencies:
@@ -6561,7 +6561,7 @@ snapshots:
       sirv: 3.0.2
       tinyglobby: 0.2.15
       tinyrainbow: 2.0.0
-      vitest: 3.2.4(@types/node@22.18.1)(@vitest/ui@3.2.4)(happy-dom@17.6.3)(jiti@2.5.1)(terser@5.44.0)(yaml@2.8.1)
+      vitest: 3.2.4(@types/node@22.16.5)(@vitest/ui@3.2.4)(happy-dom@17.6.3)(jiti@2.5.1)(terser@5.44.0)(yaml@2.8.1)
 
   '@vitest/utils@3.2.4':
     dependencies:
@@ -6661,14 +6661,14 @@ snapshots:
     dependencies:
       '@vue/devtools-kit': 7.7.7
 
-  '@vue/devtools-core@7.7.7(vite@7.1.4(@types/node@22.18.1)(jiti@2.5.1)(terser@5.44.0)(yaml@2.8.1))(vue@3.5.21(typescript@5.9.2))':
+  '@vue/devtools-core@7.7.7(vite@7.1.4(@types/node@22.16.5)(jiti@2.5.1)(terser@5.44.0)(yaml@2.8.1))(vue@3.5.21(typescript@5.9.2))':
     dependencies:
       '@vue/devtools-kit': 7.7.7
       '@vue/devtools-shared': 7.7.7
       mitt: 3.0.1
       nanoid: 5.1.5
       pathe: 2.0.3
-      vite-hot-client: 2.1.0(vite@7.1.4(@types/node@22.18.1)(jiti@2.5.1)(terser@5.44.0)(yaml@2.8.1))
+      vite-hot-client: 2.1.0(vite@7.1.4(@types/node@22.16.5)(jiti@2.5.1)(terser@5.44.0)(yaml@2.8.1))
       vue: 3.5.21(typescript@5.9.2)
     transitivePeerDependencies:
       - vite
@@ -8546,15 +8546,15 @@ snapshots:
     dependencies:
       boolbase: 1.0.0
 
-  nuxt@4.1.1(@biomejs/biome@2.2.3)(@parcel/watcher@2.5.1)(@types/node@22.18.1)(@vue/compiler-sfc@3.5.21)(db0@0.3.2)(eslint@9.35.0(jiti@2.5.1))(ioredis@5.7.0)(magicast@0.3.5)(optionator@0.9.4)(rollup@4.50.0)(terser@5.44.0)(typescript@5.9.2)(vite@7.1.4(@types/node@22.18.1)(jiti@2.5.1)(terser@5.44.0)(yaml@2.8.1))(vue-tsc@3.0.6(typescript@5.9.2))(yaml@2.8.1):
+  nuxt@4.1.1(@biomejs/biome@2.2.3)(@parcel/watcher@2.5.1)(@types/node@22.16.5)(@vue/compiler-sfc@3.5.21)(db0@0.3.2)(eslint@9.35.0(jiti@2.5.1))(ioredis@5.7.0)(magicast@0.3.5)(optionator@0.9.4)(rollup@4.50.0)(terser@5.44.0)(typescript@5.9.2)(vite@7.1.4(@types/node@22.16.5)(jiti@2.5.1)(terser@5.44.0)(yaml@2.8.1))(vue-tsc@3.0.6(typescript@5.9.2))(yaml@2.8.1):
     dependencies:
       '@nuxt/cli': 3.28.0(magicast@0.3.5)
       '@nuxt/devalue': 2.0.2
-      '@nuxt/devtools': 2.6.3(vite@7.1.4(@types/node@22.18.1)(jiti@2.5.1)(terser@5.44.0)(yaml@2.8.1))(vue@3.5.21(typescript@5.9.2))
+      '@nuxt/devtools': 2.6.3(vite@7.1.4(@types/node@22.16.5)(jiti@2.5.1)(terser@5.44.0)(yaml@2.8.1))(vue@3.5.21(typescript@5.9.2))
       '@nuxt/kit': 4.1.1(magicast@0.3.5)
       '@nuxt/schema': 4.1.1
       '@nuxt/telemetry': 2.6.6(magicast@0.3.5)
-      '@nuxt/vite-builder': 4.1.1(@biomejs/biome@2.2.3)(@types/node@22.18.1)(eslint@9.35.0(jiti@2.5.1))(magicast@0.3.5)(optionator@0.9.4)(rollup@4.50.0)(terser@5.44.0)(typescript@5.9.2)(vue-tsc@3.0.6(typescript@5.9.2))(vue@3.5.21(typescript@5.9.2))(yaml@2.8.1)
+      '@nuxt/vite-builder': 4.1.1(@biomejs/biome@2.2.3)(@types/node@22.16.5)(eslint@9.35.0(jiti@2.5.1))(magicast@0.3.5)(optionator@0.9.4)(rollup@4.50.0)(terser@5.44.0)(typescript@5.9.2)(vue-tsc@3.0.6(typescript@5.9.2))(vue@3.5.21(typescript@5.9.2))(yaml@2.8.1)
       '@unhead/vue': 2.0.14(vue@3.5.21(typescript@5.9.2))
       '@vue/shared': 3.5.21
       c12: 3.2.0(magicast@0.3.5)
@@ -8613,7 +8613,7 @@ snapshots:
       vue-router: 4.5.1(vue@3.5.21(typescript@5.9.2))
     optionalDependencies:
       '@parcel/watcher': 2.5.1
-      '@types/node': 22.18.1
+      '@types/node': 22.16.5
     transitivePeerDependencies:
       - '@azure/app-configuration'
       - '@azure/cosmos'
@@ -9838,23 +9838,23 @@ snapshots:
 
   vary@1.1.2: {}
 
-  vite-dev-rpc@1.1.0(vite@7.1.4(@types/node@22.18.1)(jiti@2.5.1)(terser@5.44.0)(yaml@2.8.1)):
+  vite-dev-rpc@1.1.0(vite@7.1.4(@types/node@22.16.5)(jiti@2.5.1)(terser@5.44.0)(yaml@2.8.1)):
     dependencies:
       birpc: 2.5.0
-      vite: 7.1.4(@types/node@22.18.1)(jiti@2.5.1)(terser@5.44.0)(yaml@2.8.1)
-      vite-hot-client: 2.1.0(vite@7.1.4(@types/node@22.18.1)(jiti@2.5.1)(terser@5.44.0)(yaml@2.8.1))
+      vite: 7.1.4(@types/node@22.16.5)(jiti@2.5.1)(terser@5.44.0)(yaml@2.8.1)
+      vite-hot-client: 2.1.0(vite@7.1.4(@types/node@22.16.5)(jiti@2.5.1)(terser@5.44.0)(yaml@2.8.1))
 
-  vite-hot-client@2.1.0(vite@7.1.4(@types/node@22.18.1)(jiti@2.5.1)(terser@5.44.0)(yaml@2.8.1)):
+  vite-hot-client@2.1.0(vite@7.1.4(@types/node@22.16.5)(jiti@2.5.1)(terser@5.44.0)(yaml@2.8.1)):
     dependencies:
-      vite: 7.1.4(@types/node@22.18.1)(jiti@2.5.1)(terser@5.44.0)(yaml@2.8.1)
+      vite: 7.1.4(@types/node@22.16.5)(jiti@2.5.1)(terser@5.44.0)(yaml@2.8.1)
 
-  vite-node@3.2.4(@types/node@22.18.1)(jiti@2.5.1)(terser@5.44.0)(yaml@2.8.1):
+  vite-node@3.2.4(@types/node@22.16.5)(jiti@2.5.1)(terser@5.44.0)(yaml@2.8.1):
     dependencies:
       cac: 6.7.14
       debug: 4.4.1
       es-module-lexer: 1.7.0
       pathe: 2.0.3
-      vite: 7.1.4(@types/node@22.18.1)(jiti@2.5.1)(terser@5.44.0)(yaml@2.8.1)
+      vite: 7.1.4(@types/node@22.16.5)(jiti@2.5.1)(terser@5.44.0)(yaml@2.8.1)
     transitivePeerDependencies:
       - '@types/node'
       - jiti
@@ -9869,7 +9869,7 @@ snapshots:
       - tsx
       - yaml
 
-  vite-plugin-checker@0.10.3(@biomejs/biome@2.2.3)(eslint@9.35.0(jiti@2.5.1))(optionator@0.9.4)(typescript@5.9.2)(vite@7.1.4(@types/node@22.18.1)(jiti@2.5.1)(terser@5.44.0)(yaml@2.8.1))(vue-tsc@3.0.6(typescript@5.9.2)):
+  vite-plugin-checker@0.10.3(@biomejs/biome@2.2.3)(eslint@9.35.0(jiti@2.5.1))(optionator@0.9.4)(typescript@5.9.2)(vite@7.1.4(@types/node@22.16.5)(jiti@2.5.1)(terser@5.44.0)(yaml@2.8.1))(vue-tsc@3.0.6(typescript@5.9.2)):
     dependencies:
       '@babel/code-frame': 7.27.1
       chokidar: 4.0.3
@@ -9879,7 +9879,7 @@ snapshots:
       strip-ansi: 7.1.0
       tiny-invariant: 1.3.3
       tinyglobby: 0.2.14
-      vite: 7.1.4(@types/node@22.18.1)(jiti@2.5.1)(terser@5.44.0)(yaml@2.8.1)
+      vite: 7.1.4(@types/node@22.16.5)(jiti@2.5.1)(terser@5.44.0)(yaml@2.8.1)
       vscode-uri: 3.1.0
     optionalDependencies:
       '@biomejs/biome': 2.2.3
@@ -9888,7 +9888,7 @@ snapshots:
       typescript: 5.9.2
       vue-tsc: 3.0.6(typescript@5.9.2)
 
-  vite-plugin-inspect@11.3.3(@nuxt/kit@3.19.1(magicast@0.3.5))(vite@7.1.4(@types/node@22.18.1)(jiti@2.5.1)(terser@5.44.0)(yaml@2.8.1)):
+  vite-plugin-inspect@11.3.3(@nuxt/kit@3.19.1(magicast@0.3.5))(vite@7.1.4(@types/node@22.16.5)(jiti@2.5.1)(terser@5.44.0)(yaml@2.8.1)):
     dependencies:
       ansis: 4.1.0
       debug: 4.4.1
@@ -9898,24 +9898,24 @@ snapshots:
       perfect-debounce: 2.0.0
       sirv: 3.0.2
       unplugin-utils: 0.3.0
-      vite: 7.1.4(@types/node@22.18.1)(jiti@2.5.1)(terser@5.44.0)(yaml@2.8.1)
-      vite-dev-rpc: 1.1.0(vite@7.1.4(@types/node@22.18.1)(jiti@2.5.1)(terser@5.44.0)(yaml@2.8.1))
+      vite: 7.1.4(@types/node@22.16.5)(jiti@2.5.1)(terser@5.44.0)(yaml@2.8.1)
+      vite-dev-rpc: 1.1.0(vite@7.1.4(@types/node@22.16.5)(jiti@2.5.1)(terser@5.44.0)(yaml@2.8.1))
     optionalDependencies:
       '@nuxt/kit': 3.19.1(magicast@0.3.5)
     transitivePeerDependencies:
       - supports-color
 
-  vite-plugin-vue-tracer@1.0.0(vite@7.1.4(@types/node@22.18.1)(jiti@2.5.1)(terser@5.44.0)(yaml@2.8.1))(vue@3.5.21(typescript@5.9.2)):
+  vite-plugin-vue-tracer@1.0.0(vite@7.1.4(@types/node@22.16.5)(jiti@2.5.1)(terser@5.44.0)(yaml@2.8.1))(vue@3.5.21(typescript@5.9.2)):
     dependencies:
       estree-walker: 3.0.3
       exsolve: 1.0.7
       magic-string: 0.30.18
       pathe: 2.0.3
       source-map-js: 1.2.1
-      vite: 7.1.4(@types/node@22.18.1)(jiti@2.5.1)(terser@5.44.0)(yaml@2.8.1)
+      vite: 7.1.4(@types/node@22.16.5)(jiti@2.5.1)(terser@5.44.0)(yaml@2.8.1)
       vue: 3.5.21(typescript@5.9.2)
 
-  vite@7.1.4(@types/node@22.18.1)(jiti@2.5.1)(terser@5.44.0)(yaml@2.8.1):
+  vite@7.1.4(@types/node@22.16.5)(jiti@2.5.1)(terser@5.44.0)(yaml@2.8.1):
     dependencies:
       esbuild: 0.25.9
       fdir: 6.5.0(picomatch@4.0.3)
@@ -9924,7 +9924,7 @@ snapshots:
       rollup: 4.50.0
       tinyglobby: 0.2.15
     optionalDependencies:
-      '@types/node': 22.18.1
+      '@types/node': 22.16.5
       fsevents: 2.3.3
       jiti: 2.5.1
       terser: 5.44.0
@@ -9947,11 +9947,11 @@ snapshots:
       - typescript
       - vitest
 
-  vitest@3.2.4(@types/node@22.18.1)(@vitest/ui@3.2.4)(happy-dom@17.6.3)(jiti@2.5.1)(terser@5.44.0)(yaml@2.8.1):
+  vitest@3.2.4(@types/node@22.16.5)(@vitest/ui@3.2.4)(happy-dom@17.6.3)(jiti@2.5.1)(terser@5.44.0)(yaml@2.8.1):
     dependencies:
       '@types/chai': 5.2.2
       '@vitest/expect': 3.2.4
-      '@vitest/mocker': 3.2.4(vite@7.1.4(@types/node@22.18.1)(jiti@2.5.1)(terser@5.44.0)(yaml@2.8.1))
+      '@vitest/mocker': 3.2.4(vite@7.1.4(@types/node@22.16.5)(jiti@2.5.1)(terser@5.44.0)(yaml@2.8.1))
       '@vitest/pretty-format': 3.2.4
       '@vitest/runner': 3.2.4
       '@vitest/snapshot': 3.2.4
@@ -9969,11 +9969,11 @@ snapshots:
       tinyglobby: 0.2.15
       tinypool: 1.1.1
       tinyrainbow: 2.0.0
-      vite: 7.1.4(@types/node@22.18.1)(jiti@2.5.1)(terser@5.44.0)(yaml@2.8.1)
-      vite-node: 3.2.4(@types/node@22.18.1)(jiti@2.5.1)(terser@5.44.0)(yaml@2.8.1)
+      vite: 7.1.4(@types/node@22.16.5)(jiti@2.5.1)(terser@5.44.0)(yaml@2.8.1)
+      vite-node: 3.2.4(@types/node@22.16.5)(jiti@2.5.1)(terser@5.44.0)(yaml@2.8.1)
       why-is-node-running: 2.3.0
     optionalDependencies:
-      '@types/node': 22.18.1
+      '@types/node': 22.16.5
       '@vitest/ui': 3.2.4(vitest@3.2.4)
       happy-dom: 17.6.3
     transitivePeerDependencies:

--- a/scripts/sync-node-version.ts
+++ b/scripts/sync-node-version.ts
@@ -1,0 +1,166 @@
+#!/usr/bin/env node
+
+/**
+ * Node.js Version Synchronization Script (TypeScript + Functional)
+ * 
+ * Volta設定を基準として、CI環境とREADMEのバージョンを自動同期
+ * @types/nodeは独立管理（パッチ更新保持のため）
+ */
+
+import { readFileSync, writeFileSync } from 'node:fs'
+import { join } from 'node:path'
+import { consola } from 'consola'
+
+// 型定義
+interface VoltaConfig {
+  node: string
+  pnpm?: string
+}
+
+interface PackageJson {
+  name: string
+  volta?: VoltaConfig
+  engines?: {
+    node?: string
+    pnpm?: string
+  }
+  dependencies?: Record<string, string>
+  devDependencies?: Record<string, string>
+}
+
+interface SyncResult {
+  file: string
+  updated: boolean
+  oldValue?: string
+  newValue?: string
+}
+
+interface SyncTarget {
+  file: string
+  pattern: RegExp
+  replacement: (version: string) => string
+  description: string
+}
+
+// ユーティリティ関数：安全なファイル読み込み
+function readFile(filePath: string): string {
+  try {
+    return readFileSync(filePath, 'utf8')
+  } catch (error) {
+    throw new Error(`Failed to read ${filePath}: ${error instanceof Error ? error.message : 'Unknown error'}`)
+  }
+}
+
+// ユーティリティ関数：安全なファイル書き込み
+function writeFile(filePath: string, content: string): void {
+  try {
+    writeFileSync(filePath, content, 'utf8')
+  } catch (error) {
+    throw new Error(`Failed to write ${filePath}: ${error instanceof Error ? error.message : 'Unknown error'}`)
+  }
+}
+
+// package.jsonからVoltaのNodeバージョンを取得
+function getBaseNodeVersion(rootDir = process.cwd()): string {
+  const packagePath = join(rootDir, 'package.json')
+  const content = readFile(packagePath)
+  
+  const packageJson: PackageJson = JSON.parse(content)
+  
+  if (!packageJson.volta?.node) {
+    throw new Error('Volta Node version not found in package.json')
+  }
+  
+  return packageJson.volta.node
+}
+
+// ファイルを安全に更新（変更があった場合のみ書き込み）
+function updateFile(rootDir: string, target: SyncTarget, version: string): SyncResult {
+  const fullPath = join(rootDir, target.file)
+  const content = readFile(fullPath)
+  
+  const match = content.match(target.pattern)
+  const oldValue = match?.[0]
+  const replacement = target.replacement(version)
+  
+  const updatedContent = content.replace(target.pattern, replacement)
+  
+  if (content === updatedContent) {
+    return {
+      file: target.file,
+      updated: false,
+      oldValue,
+      newValue: replacement
+    }
+  }
+  
+  writeFile(fullPath, updatedContent)
+  
+  return {
+    file: target.file,
+    updated: true,
+    oldValue,
+    newValue: replacement
+  }
+}
+
+// すべてのターゲットファイルを同期
+function syncAllTargets(rootDir: string, targets: SyncTarget[], version: string): SyncResult[] {
+  return targets.map(target => updateFile(rootDir, target, version))
+}
+
+// 結果をコンソールに出力
+function logResults(baseVersion: string, results: SyncResult[]): void {
+  consola.box(`📦 Base version from Volta: ${baseVersion}`)
+  
+  results.forEach(result => {
+    if (result.updated) {
+      consola.success(`Updated ${result.file}: ${result.oldValue} → ${result.newValue}`)
+    } else {
+      consola.info(`${result.file} already synchronized`)
+    }
+  })
+  
+  consola.box('🎉 Node.js version synchronization completed!')
+  consola.info(`📋 Synchronized: Volta(${baseVersion}) → CI & README`)
+  consola.info('🔧 Note: @types/node maintained independently for patches')
+}
+
+// 同期ターゲットの定義
+function createSyncTargets(): SyncTarget[] {
+  return [
+    {
+      file: '.github/workflows/ci.yaml',
+      pattern: /NODE_VERSION:\s*[\d.]+/g,
+      replacement: (version) => `NODE_VERSION: ${version}`,
+      description: 'CI environment'
+    },
+    {
+      file: 'README.md',
+      pattern: /Node\.js\*\* v[\d.]+/g,
+      replacement: (version) => `Node.js** v${version}`,
+      description: 'Documentation'
+    }
+  ]
+}
+
+// メイン処理関数
+async function main(): Promise<void> {
+  try {
+    const rootDir = process.cwd()
+    const baseVersion = getBaseNodeVersion(rootDir)
+    const targets = createSyncTargets()
+    
+    const results = syncAllTargets(rootDir, targets, baseVersion)
+    logResults(baseVersion, results)
+    
+  } catch (error) {
+    consola.error('❌ Error during synchronization:', error instanceof Error ? error.message : 'Unknown error')
+    process.exit(1)
+  }
+}
+
+// スクリプト実行時のエントリーポイント
+if (import.meta.url === `file://${process.argv[1]}`) {
+  await main()
+}

--- a/scripts/sync-node-version.ts
+++ b/scripts/sync-node-version.ts
@@ -2,128 +2,129 @@
 
 /**
  * Node.js Version Synchronization Script (TypeScript + Functional)
- * 
+ *
  * Volta設定を基準として、CI環境とREADMEのバージョンを自動同期
  * @types/nodeは独立管理（パッチ更新保持のため）
  */
 
-import { readFileSync, writeFileSync } from 'node:fs'
-import { join } from 'node:path'
-import { consola } from 'consola'
+import { readFileSync, writeFileSync } from 'node:fs';
+import { join } from 'node:path';
+import { pathToFileURL } from 'node:url';
+import { consola } from 'consola';
 
 // 型定義
 interface VoltaConfig {
-  node: string
-  pnpm?: string
+  node: string;
+  pnpm?: string;
 }
 
 interface PackageJson {
-  name: string
-  volta?: VoltaConfig
+  name: string;
+  volta?: VoltaConfig;
   engines?: {
-    node?: string
-    pnpm?: string
-  }
-  dependencies?: Record<string, string>
-  devDependencies?: Record<string, string>
+    node?: string;
+    pnpm?: string;
+  };
+  dependencies?: Record<string, string>;
+  devDependencies?: Record<string, string>;
 }
 
 interface SyncResult {
-  file: string
-  updated: boolean
-  oldValue?: string
-  newValue?: string
+  file: string;
+  updated: boolean;
+  oldValue?: string;
+  newValue?: string;
 }
 
 interface SyncTarget {
-  file: string
-  pattern: RegExp
-  replacement: (version: string) => string
-  description: string
+  file: string;
+  pattern: RegExp;
+  replacement: (version: string) => string;
+  description: string;
 }
 
 // ユーティリティ関数：安全なファイル読み込み
 function readFile(filePath: string): string {
   try {
-    return readFileSync(filePath, 'utf8')
+    return readFileSync(filePath, 'utf8');
   } catch (error) {
-    throw new Error(`Failed to read ${filePath}: ${error instanceof Error ? error.message : 'Unknown error'}`)
+    throw new Error(`Failed to read ${filePath}: ${error instanceof Error ? error.message : 'Unknown error'}`);
   }
 }
 
 // ユーティリティ関数：安全なファイル書き込み
 function writeFile(filePath: string, content: string): void {
   try {
-    writeFileSync(filePath, content, 'utf8')
+    writeFileSync(filePath, content, 'utf8');
   } catch (error) {
-    throw new Error(`Failed to write ${filePath}: ${error instanceof Error ? error.message : 'Unknown error'}`)
+    throw new Error(`Failed to write ${filePath}: ${error instanceof Error ? error.message : 'Unknown error'}`);
   }
 }
 
 // package.jsonからVoltaのNodeバージョンを取得
 function getBaseNodeVersion(rootDir = process.cwd()): string {
-  const packagePath = join(rootDir, 'package.json')
-  const content = readFile(packagePath)
-  
-  const packageJson: PackageJson = JSON.parse(content)
-  
+  const packagePath = join(rootDir, 'package.json');
+  const content = readFile(packagePath);
+
+  const packageJson: PackageJson = JSON.parse(content);
+
   if (!packageJson.volta?.node) {
-    throw new Error('Volta Node version not found in package.json')
+    throw new Error('Volta Node version not found in package.json');
   }
-  
-  return packageJson.volta.node
+
+  return packageJson.volta.node;
 }
 
 // ファイルを安全に更新（変更があった場合のみ書き込み）
 function updateFile(rootDir: string, target: SyncTarget, version: string): SyncResult {
-  const fullPath = join(rootDir, target.file)
-  const content = readFile(fullPath)
-  
-  const match = content.match(target.pattern)
-  const oldValue = match?.[0]
-  const replacement = target.replacement(version)
-  
-  const updatedContent = content.replace(target.pattern, replacement)
-  
+  const fullPath = join(rootDir, target.file);
+  const content = readFile(fullPath);
+
+  const match = content.match(target.pattern);
+  const oldValue = match?.[0];
+  const replacement = target.replacement(version);
+
+  const updatedContent = content.replace(target.pattern, replacement);
+
   if (content === updatedContent) {
     return {
       file: target.file,
       updated: false,
       oldValue,
-      newValue: replacement
-    }
+      newValue: replacement,
+    };
   }
-  
-  writeFile(fullPath, updatedContent)
-  
+
+  writeFile(fullPath, updatedContent);
+
   return {
     file: target.file,
     updated: true,
     oldValue,
-    newValue: replacement
-  }
+    newValue: replacement,
+  };
 }
 
 // すべてのターゲットファイルを同期
 function syncAllTargets(rootDir: string, targets: SyncTarget[], version: string): SyncResult[] {
-  return targets.map(target => updateFile(rootDir, target, version))
+  return targets.map((target) => updateFile(rootDir, target, version));
 }
 
 // 結果をコンソールに出力
 function logResults(baseVersion: string, results: SyncResult[]): void {
-  consola.box(`📦 Base version from Volta: ${baseVersion}`)
-  
-  results.forEach(result => {
+  consola.box(`📦 Base version from Volta: ${baseVersion}`);
+
+  results.forEach((result) => {
     if (result.updated) {
-      consola.success(`Updated ${result.file}: ${result.oldValue} → ${result.newValue}`)
+      consola.success(`Updated ${result.file}: ${result.oldValue} → ${result.newValue}`);
     } else {
-      consola.info(`${result.file} already synchronized`)
+      consola.info(`${result.file} already synchronized`);
     }
-  })
-  
-  consola.box('🎉 Node.js version synchronization completed!')
-  consola.info(`📋 Synchronized: Volta(${baseVersion}) → CI & README`)
-  consola.info('🔧 Note: @types/node maintained independently for patches')
+  });
+
+  consola.box('🎉 Node.js version synchronization completed!');
+  consola.info(`📋 Synchronized: Volta(${baseVersion}) → CI & README`);
+  consola.info('🔧 Note: @types/node maintained independently for patches');
 }
 
 // 同期ターゲットの定義
@@ -131,36 +132,34 @@ function createSyncTargets(): SyncTarget[] {
   return [
     {
       file: '.github/workflows/ci.yaml',
-      pattern: /NODE_VERSION:\s*[\d.]+/g,
+      pattern: /NODE_VERSION:\s*[\d.]+/,
       replacement: (version) => `NODE_VERSION: ${version}`,
-      description: 'CI environment'
+      description: 'CI environment',
     },
     {
       file: 'README.md',
-      pattern: /Node\.js\*\* v[\d.]+/g,
+      pattern: /Node\.js\*\* v[\d.]+/,
       replacement: (version) => `Node.js** v${version}`,
-      description: 'Documentation'
-    }
-  ]
+      description: 'Documentation',
+    },
+  ];
 }
 
 // メイン処理関数
 async function main(): Promise<void> {
   try {
-    const rootDir = process.cwd()
-    const baseVersion = getBaseNodeVersion(rootDir)
-    const targets = createSyncTargets()
-    
-    const results = syncAllTargets(rootDir, targets, baseVersion)
-    logResults(baseVersion, results)
-    
+    const rootDir = process.cwd();
+    const baseVersion = getBaseNodeVersion(rootDir);
+    const targets = createSyncTargets();
+
+    const results = syncAllTargets(rootDir, targets, baseVersion);
+    logResults(baseVersion, results);
   } catch (error) {
-    consola.error('❌ Error during synchronization:', error instanceof Error ? error.message : 'Unknown error')
-    process.exit(1)
+    consola.error('❌ Error during synchronization:', error instanceof Error ? error.message : 'Unknown error');
+    process.exit(1);
   }
 }
 
-// スクリプト実行時のエントリーポイント
-if (import.meta.url === `file://${process.argv[1]}`) {
-  await main()
+if (import.meta.url === pathToFileURL(process.argv[1]).href) {
+  await main();
 }


### PR DESCRIPTION
- close #23 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- ドキュメント
  - 環境要件を更新: Node.js 最低バージョンを v22.16.0、pnpm を v10.15.1 に変更。
  - プロジェクト概要と README の Node.js 表記を整合。
- チョア
  - CI と開発環境の Node.js バージョンを v22.16.0 に統一（Volta 設定を含む）。
  - package.json に同期用スクリプトを追加（README/CI の Node 表記を自動同期）。
  - 型定義 (@types/node) を v22.16.5 に更新。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->